### PR TITLE
Added on_error and on_stdout handlers to Comm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,12 +48,6 @@ jobs:
 
     - stage: test_jlab
       before_install:
-        - wget https://github.com/mozilla/geckodriver/releases/download/v0.11.1/geckodriver-v0.11.1-linux64.tar.gz
-        - mkdir geckodriver
-        - tar -xzf geckodriver-v0.11.1-linux64.tar.gz -C geckodriver
-        - export PATH=$PATH:$PWD/geckodriver
-        - export DISPLAY=:99.0
-        - sh -e /etc/init.d/xvfb start || true
         - pip install pyctdev && doit miniconda_install && pip uninstall -y doit pyctdev
         - export PATH="$HOME/miniconda/bin:$PATH" && hash -r
         - conda config --set always_yes True
@@ -61,15 +55,14 @@ jobs:
       install:
         - doit env_create $CHANS_DEV --python=$PYENV_VERSION
         - source activate test-environment
-        - conda install nodejs notebook selenium
+        - conda install nodejs notebook
         - pip install --pre jupyterlab
       script:
         - npm install
         - npm run build
-        - jupyter labextension install .
-        - jupyter lab clean
-        - jupyter labextension link .
-        - python -m jupyterlab.selenium_check
+        - jupyter labextension install --no-build
+        - NODE_OPTIONS=--max-old-space-size=16000 jupyter lab build
+        - python -m jupyterlab.browser_check
 
     ########## END-USER PACKAGES ##########
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
 
 env:
   global:
-    - PYENV_VERSION=3.6
+    - PYENV_VERSION=3.7
     - CHANS_DEV="-c pyviz/label/dev"
     - CHANS="-c pyviz"
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 #          python version             test group                  extra envs  extra commands       
-envlist = {py27,py35,py36}-{flakes,all_recommended}-{default}-{dev,pkg}
+envlist = {py27,py35,py36,py37}-{flakes,all_recommended}-{default}-{dev,pkg}
 
 [_flakes]
 description = Flake check python and notebooks


### PR DESCRIPTION
For a **very** long time our Comms have routed errors and stdout output back to the JS side since we didn't see a clear way for them to route their output to the cell the output is displayed in. This PR adds `on_error` and `on_stdout` handlers which can process the output as required by the library using them, e.g. Panel will create a display handle for each output which it will route any error messages and stdout output to but other libraries can register a handler to log the output or do whatever else they want to do with it.