### PR TITLE
Added try/except for retrieving library version

### DIFF
--- a/pyviz_comms/__init__.py
+++ b/pyviz_comms/__init__.py
@@ -10,8 +10,11 @@ except:
 
 import param
 
-__version__ = str(param.version.Version(fpath=__file__, archive_commit="$Format:%h$",
-                                        reponame="pyviz_comms"))
+try:
+    __version__ = str(param.version.Version(fpath=__file__, archive_commit="$Format:%h$",
+                                            reponame="pyviz_comms"))
+except:
+    __version__ = "0.0.0+unknown"
 
 
 # nb_mime_js is used to enable the necessary mime type support in classic notebook

--- a/pyviz_comms/__init__.py
+++ b/pyviz_comms/__init__.py
@@ -13,7 +13,7 @@ import param
 try:
     __version__ = str(param.version.Version(fpath=__file__, archive_commit="$Format:%h$",
                                             reponame="pyviz_comms"))
-except:
+except Exception:
     __version__ = "0.0.0+unknown"
 
 


### PR DESCRIPTION
In some weird environments, `param`'s way of retrieving version information has many bugs (since it opens a subprocess to call git, for instance, which gives problems when Python processes are created with systems such as Supervisor or Gunicorn). This commit adds the option for the library to keep on going, even if the version cannot be correctly retreived.

This is just the way it is also done in https://github.com/holoviz/param/blob/7d2d2a848dc79d9741709702f8b47f87497701b0/param/__init__.py#L46