### PR TITLE
Track execution counts of extensions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
+          node-version: '12.x'
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install node
       uses: actions/setup-node@v1
       with:
-       node-version: '10.x'
+       node-version: '12.x'
     - name: Install Python
       uses: actions/setup-python@v2
       with:

--- a/pyviz_comms/__init__.py
+++ b/pyviz_comms/__init__.py
@@ -44,12 +44,12 @@ class extension(param.ParameterizedFunction):
 
     # Records the execution_count at each execution of an extension
     _last_execution_count = None
-    _repeat_execution = False
+    _repeat_execution_in_cell = False
 
     def __new__(cls, *args, **kwargs):
         try:
             exec_count = get_ipython().execution_count
-            cls._repeat_execution = (exec_count == cls._last_execution_count)
+            cls._repeat_execution_in_cell = (exec_count == cls._last_execution_count)
             cls._last_execution_count = exec_count
         except Exception:
             pass

--- a/pyviz_comms/__init__.py
+++ b/pyviz_comms/__init__.py
@@ -42,6 +42,19 @@ class extension(param.ParameterizedFunction):
     # A registry of actions to perform when a server delete event is received
     _server_delete_actions = []
 
+    # Records the execution_count at each execution of an extension
+    _last_execution_count = None
+    _repeat_execution = False
+
+    def __new__(cls, *args, **kwargs):
+        try:
+            exec_count = get_ipython().execution_count
+            cls._repeat_execution = (exec_count == cls._last_execution_count)
+            cls._last_execution_count = exec_count
+        except Exception:
+            pass
+        return param.ParameterizedFunction.__new__(cls, *args, **kwargs)
+
     @classmethod
     def add_delete_action(cls, action):
         cls._delete_actions.append(action)


### PR DESCRIPTION
This will allow individual extensions to decide whether to re-embed resources if there are multiple calls to the extension in the same notebook cell.