### PR TITLE
Install the tests options in the build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test
-          doit develop_install $CHANS_DEV -o build -o test
+          doit develop_install $CHANS_DEV -o build -o tests
           pip uninstall -y pyviz_comms
       - name: npm setup
         run: |
@@ -111,7 +111,7 @@ jobs:
         run: |
           eval "$(conda shell.bash hook)"
           conda activate test-environment
-          doit develop_install $CHANS_DEV -o build -o test
+          doit develop_install $CHANS_DEV -o build -o tests
           pip uninstall -y pyviz_comms
           doit pip_on_conda
       - name: npm setup


### PR DESCRIPTION
In previous versions of pyctdev the `tests` options were installed by default. pyviz_comms declared `-o test` which was a typo since its test options is named `tests`, so after the recent releases of pyctdev the test options ended up no longer being installed. 