### PR TITLE
Update the count on the base extension class

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
+          node-version: 14
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
@@ -93,9 +93,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '12.x'
+          node-version: 14
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Install node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
-       node-version: '12.x'
+       node-version: 14
     - name: Install Python
       uses: actions/setup-python@v2
       with:

--- a/pyviz_comms/__init__.py
+++ b/pyviz_comms/__init__.py
@@ -50,7 +50,9 @@ class extension(param.ParameterizedFunction):
         try:
             exec_count = get_ipython().execution_count
             cls._repeat_execution_in_cell = (exec_count == cls._last_execution_count)
-            cls._last_execution_count = exec_count
+            # Update the last count on this base class only so that every new instance
+            # creation obtains the updated count.
+            extension._last_execution_count = exec_count
         except Exception:
             pass
         return param.ParameterizedFunction.__new__(cls, *args, **kwargs)


### PR DESCRIPTION
Fixes https://github.com/holoviz/pyviz_comms/issues/96 by updating the count on the base class directly, so that every new instance creation inherits the updated value.

An alternative implementation would have been to wrap `_last_execution_count` in a list, .e.g `[None]`, and only update the content of that list. I chose the submitted implementation as it seemed cleaner, and doesn't change `_last_execution_count` (even if it's not used directly by Panel or HoloViews, they access `__repeat_execution_in_cell`).