### PR TITLE
Fix extension repeat count

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -42,8 +42,11 @@ jobs:
       run: |
         jlpm
         jlpm run eslint:check
-        python -m pip install . --no-build-isolation
+        python -m pip install .[tests] --no-build-isolation
     - name: Check extension
       run: |
         jupyter labextension list 2>&1 | grep -ie "jupyterlab_pyviz.*OK"
         python -m jupyterlab.browser_check
+    - name: Run tests
+      run: |
+        python -m pytest pyviz_comms

--- a/dodo.py
+++ b/dodo.py
@@ -12,6 +12,4 @@ def task_pip_on_conda():
         'conda install -y pip twine wheel',
         # ..and some are only available via conda-forge
         'conda install -y -c conda-forge tox virtualenv',
-        # this interferes with pip-installed nose
-        'conda remove -y --force nose'
     ]}

--- a/pyviz_comms/__init__.py
+++ b/pyviz_comms/__init__.py
@@ -24,6 +24,12 @@ def _jupyter_labextension_paths():
         'dest': data['name']
     }]
 
+# Required only to monkeypatch get_ipython in the test suite
+try:
+  get_ipython()
+except NameError:
+  get_ipython = None
+
 # nb_mime_js is used to enable the necessary mime type support in classic notebook
 comm_path = os.path.dirname(os.path.abspath(__file__))
 with open(os.path.join(comm_path, 'notebook.js')) as f:

--- a/pyviz_comms/__init__.py
+++ b/pyviz_comms/__init__.py
@@ -49,7 +49,7 @@ class extension(param.ParameterizedFunction):
     def __new__(cls, *args, **kwargs):
         try:
             exec_count = get_ipython().execution_count
-            cls._repeat_execution_in_cell = (exec_count == cls._last_execution_count)
+            extension._repeat_execution_in_cell = (exec_count == cls._last_execution_count)
             # Update the last count on this base class only so that every new instance
             # creation obtains the updated count.
             extension._last_execution_count = exec_count

--- a/pyviz_comms/tests/test_extension.py
+++ b/pyviz_comms/tests/test_extension.py
@@ -1,0 +1,314 @@
+import pytest
+import pyviz_comms
+from pyviz_comms import extension
+
+
+# Store the default values to reset them in the get_ipython fixture
+LAST_EXECUTION_COUNT = extension._last_execution_count
+REPEAT_EXECUTION_IN_CELL = extension._repeat_execution_in_cell
+
+
+@pytest.fixture
+def get_ipython():
+    # Provide a mock on which `get_ipython().execution_count` returns
+    # an integer.
+
+    class ExecutionCount:
+        execution_count = 1
+
+        @classmethod
+        def bump(cls):
+            # Used to emulate running code in the next cell.
+            cls.execution_count += 1
+
+    def _get_ipython():
+        return ExecutionCount
+    
+    yield _get_ipython
+
+    extension._last_execution_count = LAST_EXECUTION_COUNT
+    extension._repeat_execution_in_cell = REPEAT_EXECUTION_IN_CELL
+
+
+def test_get_ipython_fixture(monkeypatch, get_ipython):
+    # Test the get_ipython fixture
+
+    monkeypatch.setattr(pyviz_comms, 'get_ipython', get_ipython)
+
+    class sub_extension(extension):
+        def __call__(self, *args, **params):
+            pass
+
+    sub_extension()
+
+    assert sub_extension._last_execution_count == 1
+
+    sub_extension()
+
+    assert sub_extension._last_execution_count == 1
+
+    get_ipython().bump()
+
+    sub_extension()
+
+    assert sub_extension._last_execution_count == 2
+
+
+def test_get_ipython_fixture_reset(get_ipython):
+
+    assert extension._last_execution_count == LAST_EXECUTION_COUNT
+    assert extension._repeat_execution_in_cell == REPEAT_EXECUTION_IN_CELL
+
+
+def test_extension_count_one_cell_one_extension(monkeypatch, get_ipython):
+
+    monkeypatch.setattr(pyviz_comms, 'get_ipython', get_ipython)
+
+    class sub_extension(extension):
+        def __call__(self, *args, **params):
+            pass
+
+    sub_extension()
+
+    assert sub_extension._repeat_execution_in_cell is False
+    assert sub_extension._repeat_execution_in_cell == extension._repeat_execution_in_cell
+
+    sub_extension()
+
+    assert sub_extension._repeat_execution_in_cell is True
+    assert sub_extension._repeat_execution_in_cell == extension._repeat_execution_in_cell
+
+    sub_extension()
+
+    assert sub_extension._repeat_execution_in_cell is True
+    assert sub_extension._repeat_execution_in_cell == extension._repeat_execution_in_cell
+
+
+def test_extension_count_one_cell_extensions_branched(monkeypatch, get_ipython):
+
+    monkeypatch.setattr(pyviz_comms, 'get_ipython', get_ipython)
+
+    class sub_extension1(extension):
+        def __call__(self, *args, **params):
+            pass
+
+    class sub_extension2(extension):
+        def __call__(self, *args, **params):
+            pass
+
+    sub_extension1()
+
+    assert sub_extension1._repeat_execution_in_cell is False
+
+    sub_extension2()
+
+    assert sub_extension2._repeat_execution_in_cell is True
+    assert sub_extension2._repeat_execution_in_cell == sub_extension1._repeat_execution_in_cell
+    assert sub_extension1._repeat_execution_in_cell == extension._repeat_execution_in_cell
+
+
+def test_extension_count_one_cell_parent_first(monkeypatch, get_ipython):
+
+    monkeypatch.setattr(pyviz_comms, 'get_ipython', get_ipython)
+
+    class parent_extension(extension):
+        def __call__(self, *args, **params):
+            pass
+
+    class sub_extension(parent_extension):
+        def __call__(self, *args, **params):
+            pass
+
+    parent_extension()
+
+    assert parent_extension._repeat_execution_in_cell is False
+
+    sub_extension()
+
+    assert sub_extension._repeat_execution_in_cell is True
+
+    parent_extension()
+
+    assert parent_extension._repeat_execution_in_cell is True
+
+
+def test_extension_count_one_cell_subclass_first(monkeypatch, get_ipython):
+
+    monkeypatch.setattr(pyviz_comms, 'get_ipython', get_ipython)
+
+    class parent_extension(extension):
+        def __call__(self, *args, **params):
+            pass
+
+    class sub_extension(parent_extension):
+        def __call__(self, *args, **params):
+            pass
+
+    sub_extension()
+
+    assert sub_extension._repeat_execution_in_cell is False
+
+    parent_extension()
+
+    assert parent_extension._repeat_execution_in_cell is True
+
+
+def test_extension_count_two_cells_one_extension(monkeypatch, get_ipython):
+
+    monkeypatch.setattr(pyviz_comms, 'get_ipython', get_ipython)
+
+    class sub_extension(extension):
+        def __call__(self, *args, **params):
+            pass
+
+    sub_extension()
+
+    get_ipython().bump()
+
+    sub_extension()
+
+    assert sub_extension._repeat_execution_in_cell is False
+    assert sub_extension._repeat_execution_in_cell == extension._repeat_execution_in_cell
+
+    sub_extension()
+
+    assert sub_extension._repeat_execution_in_cell is True
+    assert sub_extension._repeat_execution_in_cell == extension._repeat_execution_in_cell
+
+    get_ipython().bump()
+
+    sub_extension()
+
+    assert sub_extension._repeat_execution_in_cell is False
+    assert sub_extension._repeat_execution_in_cell == extension._repeat_execution_in_cell
+
+
+def test_extension_count_two_cells_extensions_branched(monkeypatch, get_ipython):
+
+    monkeypatch.setattr(pyviz_comms, 'get_ipython', get_ipython)
+
+    class sub_extension1(extension):
+        def __call__(self, *args, **params):
+            pass
+
+    class sub_extension2(extension):
+        def __call__(self, *args, **params):
+            pass
+
+    sub_extension1()
+
+    get_ipython().bump()
+
+    sub_extension2()
+
+    assert sub_extension2._repeat_execution_in_cell is False
+    assert sub_extension2._repeat_execution_in_cell == sub_extension1._repeat_execution_in_cell
+    assert sub_extension1._repeat_execution_in_cell == extension._repeat_execution_in_cell
+
+    sub_extension2()
+
+    assert sub_extension2._repeat_execution_in_cell is True
+    assert sub_extension2._repeat_execution_in_cell == sub_extension1._repeat_execution_in_cell
+    assert sub_extension1._repeat_execution_in_cell == extension._repeat_execution_in_cell
+
+    get_ipython().bump()
+
+    sub_extension1()
+
+    assert sub_extension1._repeat_execution_in_cell is False
+    assert sub_extension1._repeat_execution_in_cell == sub_extension2._repeat_execution_in_cell
+    assert sub_extension2._repeat_execution_in_cell == extension._repeat_execution_in_cell
+
+    get_ipython().bump()
+
+    sub_extension2()
+
+    assert sub_extension2._repeat_execution_in_cell is False
+    assert sub_extension2._repeat_execution_in_cell == sub_extension1._repeat_execution_in_cell
+    assert sub_extension1._repeat_execution_in_cell == extension._repeat_execution_in_cell
+
+
+def test_extension_count_two_cells_parent_first(monkeypatch, get_ipython):
+
+    monkeypatch.setattr(pyviz_comms, 'get_ipython', get_ipython)
+
+    class parent_extension(extension):
+        def __call__(self, *args, **params):
+            pass
+
+    class sub_extension(parent_extension):
+        def __call__(self, *args, **params):
+            pass
+
+    parent_extension()
+
+    get_ipython().bump()
+
+    sub_extension()
+
+    assert sub_extension._repeat_execution_in_cell is False
+    assert sub_extension._repeat_execution_in_cell == parent_extension._repeat_execution_in_cell
+    assert parent_extension._repeat_execution_in_cell == extension._repeat_execution_in_cell
+
+    sub_extension()
+
+    assert sub_extension._repeat_execution_in_cell is True
+    assert sub_extension._repeat_execution_in_cell == parent_extension._repeat_execution_in_cell
+    assert parent_extension._repeat_execution_in_cell == extension._repeat_execution_in_cell
+
+    parent_extension()
+
+    assert parent_extension._repeat_execution_in_cell is True
+    assert parent_extension._repeat_execution_in_cell == sub_extension._repeat_execution_in_cell
+    assert sub_extension._repeat_execution_in_cell == extension._repeat_execution_in_cell
+
+    get_ipython().bump()
+
+    parent_extension()
+
+    assert parent_extension._repeat_execution_in_cell is False
+    assert parent_extension._repeat_execution_in_cell == sub_extension._repeat_execution_in_cell
+    assert sub_extension._repeat_execution_in_cell == extension._repeat_execution_in_cell
+
+
+def test_extension_count_two_cells_subclass_first(monkeypatch, get_ipython):
+
+    monkeypatch.setattr(pyviz_comms, 'get_ipython', get_ipython)
+
+    class parent_extension(extension):
+        def __call__(self, *args, **params):
+            pass
+
+    class sub_extension(parent_extension):
+        def __call__(self, *args, **params):
+            pass
+
+    sub_extension()
+
+    get_ipython().bump()
+
+    parent_extension()
+
+    assert parent_extension._repeat_execution_in_cell is False
+    assert parent_extension._repeat_execution_in_cell == sub_extension._repeat_execution_in_cell
+    assert sub_extension._repeat_execution_in_cell == extension._repeat_execution_in_cell
+
+    parent_extension()
+
+    assert parent_extension._repeat_execution_in_cell is True
+    assert parent_extension._repeat_execution_in_cell == sub_extension._repeat_execution_in_cell
+    assert sub_extension._repeat_execution_in_cell == extension._repeat_execution_in_cell
+
+    sub_extension()
+
+    assert sub_extension._repeat_execution_in_cell is True
+    assert sub_extension._repeat_execution_in_cell == parent_extension._repeat_execution_in_cell
+    assert parent_extension._repeat_execution_in_cell == extension._repeat_execution_in_cell
+
+    get_ipython().bump()
+
+    sub_extension()
+
+    assert sub_extension._repeat_execution_in_cell is False
+    assert sub_extension._repeat_execution_in_cell == parent_extension._repeat_execution_in_cell
+    assert parent_extension._repeat_execution_in_cell == extension._repeat_execution_in_cell

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ except:
     cmdclass = {}
 
 extras_require = {
-    'tests': ['flake8', 'nose'], # nose required due to pip_on_conda
+    'tests': ['flake8', 'pytest'],
     'build': [
         'setuptools>=40.8.0,<61',
         'jupyterlab ~=3.0',
@@ -85,6 +85,7 @@ install_requires = ['param']
 setup_args = dict(
     name=name,
     version=version,
+    python_requires=">=3.6",
     install_requires=install_requires,
     extras_require=extras_require,
     tests_require=extras_require['tests'],
@@ -95,7 +96,7 @@ setup_args = dict(
     author="Philipp Rudiger",
     author_email= "philipp.jfr@gmail.com",
     maintainer= "HoloViz",
-    maintainer_email= "developers@pyviz.org",
+    maintainer_email= "developers@holoviz.org",
     platforms=['Windows', 'Mac OS X', 'Linux'],
     license='BSD',
     url='https://holoviz.org',
@@ -104,9 +105,11 @@ setup_args = dict(
     classifiers = [
         "License :: OSI Approved :: BSD License",
         "Development Status :: 5 - Production/Stable",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Operating System :: OS Independent",
         "Intended Audience :: Science/Research",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 #          python version             test group                  extra envs  extra commands       
-envlist = {py27,py35,py36,py37,py38}-{browser, flakes,all_recommended}-{default}-{dev,pkg}
+envlist = {py27,py35,py36,py37,py38,py39,py310}-{browser, flakes,all_recommended}-{default}-{dev,pkg}
 build = wheel
 
 [_flakes]
@@ -11,25 +11,31 @@ description = Flake check python and notebooks
 deps = .[tests]
 commands = flake8
 
+[_unit]
+description = Run unit tests with coverage
+deps = .[examples, tests]
+commands = pytest pyviz_comms
+
 [_browser]
 deps = .[tests]
 commands = python -m jupyterlab.browser_check
-
 
 [_all_recommended]
 description = Run all recommended tests
 deps = .[build, tests]
 commands = {[_browser]commands}
            {[_flakes]commands}
+           {[_unit]commands}
 
 [testenv]
 sitepackages = True
-install_command = pip install --no-deps {opts} nose {packages}
+install_command = pip install --no-deps {opts} {packages}
 
 changedir = {envtmpdir}
 
 commands = browser: {[_browser]commands}
            flakes: {[_flakes]commands}
+           unit: {[_unit]commands}
 
 deps = browser: {[_browser]deps}
        flakes: {[_flakes]deps}


### PR DESCRIPTION
As hinted by @philippjfr https://github.com/holoviz/pyviz_comms/pull/97 was not quite complete as it did not carry on the update of `_repeat_execution_in_cell` after an extension instantiation. For some reason I thought it was okay, after adding some tests it appeared that was incorrect.

As I did not explain the original issue very well, here is a small example that reproduces the state of the extension behavior before https://github.com/holoviz/pyviz_comms/pull/97:

![image](https://user-images.githubusercontent.com/35924738/181758911-751ad576-c124-4dc9-b73f-1aa47665a824.png)

The problem when `Subclass` was instantiated before `Parent` was that the updates of `_last_execution_count` and `_repeat_execution_in_cell` were only applied to the subclass, the parent class and its other subclasses (not inheriting from `Subclass`) would not see those changes. It's equivalent to:

![image](https://user-images.githubusercontent.com/35924738/181765584-eeeb8153-c0f6-4cb1-a1a6-6d5b0bdcdf29.png)

So this PR also adds some unit tests, and adds an extra dependency on `pytest` to run the tests instead of `nose`. The tests workflow doesn't use `pyctdev` as it was not set up to do so, this could be done another time.