### PR TITLE
Run the cron jobs weekly

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,8 +18,7 @@ on:
         required: true
         default: dryrun
   schedule:
-    # Every first sunday of the month at 9am
-    - cron: '0 9 1-7 * SUN'
+    - cron: '0 7 * * SUN'
 
 jobs:
   conda_build:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,8 +9,8 @@ on:
     - '*'
   workflow_dispatch:
   schedule:
-    # Every first sunday of the month at 10am
-    - cron: '0 10 1-7 * SUN'
+    - cron: '0 7 * * SUN'
+
 
 jobs:
   test:


### PR DESCRIPTION
For some reason the CRON jobs I defined were not running once a month on the first Sunday but on every day of the first week of the month and on every Sunday... Going to go for once a week on Sunday since I know how to set this up.