### PR TITLE
Add loading indicators for Panel Preview

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -1,0 +1,35 @@
+.jp-PanelPreview-renderOnSave {
+  display: flex;
+  align-items: center;
+}
+
+.jp-PanelPreview-loading {
+  background: rgba(0, 0, 0, 0.05);
+  pointer-events: none;
+  position: relative;
+}
+
+.jp-PanelPreview-loading::before {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 80px;
+  height: 80px;
+  border: 8px solid rgb(48, 112, 146);
+  border-left-color: #666;
+  border-radius: 50%;
+  animation: spin 1s infinite linear;
+  z-index: 9999;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/style/index.css
+++ b/style/index.css
@@ -1,5 +1,1 @@
 @import url('base.css');
-
-.jp-PanelPreview-renderOnSave {
-  align-items: center;
-}


### PR DESCRIPTION
On initial load:

<img width="1697" alt="Screen Shot 2023-06-08 at 12 32 55" src="https://github.com/holoviz/pyviz_comms/assets/1550771/b811ec48-6e57-4b4e-ad05-b3d7529e3c7a">

On reload:

<img width="1701" alt="Screen Shot 2023-06-08 at 12 35 04" src="https://github.com/holoviz/pyviz_comms/assets/1550771/3c486eb3-8c58-45ef-bbbb-553976647fae">
