### PR TITLE
Add tippy.js based tooltip

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
 requirements:
   build:
     - jupyter-packaging
-    - jupyterlab
+    - jupyterlab <4
     - notebook
     - python
     - setuptools

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "@jupyterlab/settingregistry": "^3.1.0",
     "@jupyterlab/ui-components": "^3.1.0",
     "@lumino/coreutils": "^1.5.3",
-    "@lumino/signaling": "^1.4.3"
+    "@lumino/signaling": "^1.4.3",
+    "tippy.js": "^6"
   },
   "resolutions": {
     "@lumino/widgets": "^1.37.2",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -80,6 +80,15 @@ export namespace CommandIDs {
   export const lumenOpen = 'notebook:open-with-lumen';
 }
 
+const TOOLTIP_CONTENT = `
+<span>Preview with Panel<span>
+<br>
+<br>
+<span>
+  <b>Note:</b> Your notebook must publish Panel contents with .servable().
+<span>
+`
+
 /**
  * A notebook widget extension that adds a panel preview button to the toolbar.
  */
@@ -108,8 +117,9 @@ class PanelRenderButton
     setTimeout(() => {
       requestAnimationFrame(() => {
         tippy(button.node, {
+          allowHTML: true,
           arrow: true,
-          content: 'Preview with Panel',
+          content: TOOLTIP_CONTENT,
           placement: 'bottom'
         });
       });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -54,7 +54,10 @@ import {
 export type INBWidgetExtension = DocumentRegistry.IWidgetExtension<
   NotebookPanel,
   INotebookModel
->;
+  >;
+
+import tippy from 'tippy.js';
+import 'tippy.js/dist/tippy.css'; // optional for styling
 
 let registerWidgetManager: any = null;
 try {
@@ -96,12 +99,21 @@ class PanelRenderButton
   createNew(panel: NotebookPanel): IDisposable {
     const button = new ToolbarButton({
       className: 'panelRender',
-      tooltip: 'Render with Panel',
       icon: panelIcon,
       onClick: (): void => {
         this._commands.execute(CommandIDs.panelRender);
       }
     });
+
+    setTimeout(() => {
+      requestAnimationFrame(() => {
+	tippy(button.node, {
+	  arrow: true,
+	  content: 'Preview with Panel',
+	  placement: 'bottom'
+	});
+      });
+    }, 0);
 
     panel.toolbar.insertAfter('cellType', 'panelRender', button);
     return button;
@@ -129,12 +141,21 @@ class LumenRenderButton
   createNew(panel: NotebookPanel): IDisposable {
     const button = new ToolbarButton({
       className: 'lumenRender',
-      tooltip: 'Render with Lumen',
       icon: panelIcon,
       onClick: () => {
         this._commands.execute(CommandIDs.lumenRender);
       }
     });
+
+    setTimeout(() => {
+      requestAnimationFrame(() => {
+	tippy(button.node, {
+	  arrow: true,
+	  content: 'Preview with Lumen',
+	  placement: 'bottom'
+	});
+      });
+    }, 0);
 
     panel.toolbar.addItem('lumenRender', button);
     return button;
@@ -318,7 +339,7 @@ export const extension: JupyterFrontEndPlugin<IPanelPreviewTracker> = {
     const { commands, docRegistry } = app;
 
     commands.addCommand(CommandIDs.panelRender, {
-      label: 'Render Notebook with Panel',
+      label: 'Preview Notebook with Panel',
       execute: async args => {
         const current = getCurrent(args);
         let context: DocumentRegistry.IContext<INotebookModel>;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -54,7 +54,7 @@ import {
 export type INBWidgetExtension = DocumentRegistry.IWidgetExtension<
   NotebookPanel,
   INotebookModel
-  >;
+>;
 
 import tippy from 'tippy.js';
 import 'tippy.js/dist/tippy.css'; // optional for styling
@@ -107,11 +107,11 @@ class PanelRenderButton
 
     setTimeout(() => {
       requestAnimationFrame(() => {
-	tippy(button.node, {
-	  arrow: true,
-	  content: 'Preview with Panel',
-	  placement: 'bottom'
-	});
+        tippy(button.node, {
+          arrow: true,
+          content: 'Preview with Panel',
+          placement: 'bottom'
+        });
       });
     }, 0);
 
@@ -149,11 +149,11 @@ class LumenRenderButton
 
     setTimeout(() => {
       requestAnimationFrame(() => {
-	tippy(button.node, {
-	  arrow: true,
-	  content: 'Preview with Lumen',
-	  placement: 'bottom'
-	});
+        tippy(button.node, {
+          arrow: true,
+          content: 'Preview with Lumen',
+          placement: 'bottom'
+        });
       });
     }, 0);
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -87,7 +87,7 @@ const TOOLTIP_CONTENT = `
 <span>
   <b>Note:</b> Your notebook must publish Panel contents with .servable().
 <span>
-`
+`;
 
 /**
  * A notebook widget extension that adds a panel preview button to the toolbar.


### PR DESCRIPTION
The default tooltips are simply to slow to render:

![tippy_pyviz_comms](https://github.com/holoviz/pyviz_comms/assets/1550771/b5065f19-85cc-4e21-9b76-e7d28684a0eb)
