### PR TITLE
Publish again to the `pyviz` channel

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -13,24 +13,29 @@ build:
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
-  build:
-    - jupyter-packaging
-    - jupyterlab <4
-    - notebook
-    - python
-    - setuptools
+  host:
+    - python >=3.6
     - param
+    - pip
+    - jupyter-packaging >=0.7.9,<0.8
+    - jupyterlab >=4.0,<5
+    - notebook
+    - hatchling
+    - hatch-nodejs-version
+    - hatch-jupyter-builder
   run:
-    - python
+    - python >=3.6
     - param
   run_constrained:
-    - jupyterlab >=3.0.0,<4
+    - jupyterlab >=4.0,<5
 
 test:
   imports:
     - pyviz_comms
 
 about:
-  home: www.pyviz.org
+  home: https://www.holoviz.org
   summary: Bidirectional communication for PyViz
-  license: BSD 3-Clause
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.8
     - param
     - pip
     - jupyter-packaging >=0.7.9,<0.8
@@ -24,7 +24,7 @@ requirements:
     - hatch-nodejs-version
     - hatch-jupyter-builder
   run:
-    - python >=3.6
+    - python >=3.8
     - param
   run_constrained:
     - jupyterlab >=4.0,<5


### PR DESCRIPTION
I just created a dev environment for hvPlot and it pulled an older version of pyviz_comms from the `pyviz/label/dev` channel together with jupyterlab 4 from `conda-forge`. I thought first that it was because the recipe in this repo was outdated, before I realized this repo is no longer set up to publish to Anaconda.org.