### PR TITLE
Add save handler for Panel Layout Builder

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -1,27 +1,72 @@
 import { IDisposable } from '@lumino/disposable';
+import { JSONExt } from '@lumino/coreutils';
+
+import {
+  URLExt,
+  PageConfig,
+} from '@jupyterlab/coreutils';
 
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 
-import { Kernel } from '@jupyterlab/services';
+import { Kernel, ServerConnection } from '@jupyterlab/services';
+
+import { JupyterFrontEnd } from '@jupyterlab/application';
+
+const fetch = ServerConnection.makeRequest;
+
+const API_ROOT = URLExt.join(PageConfig.getBaseUrl(), '/panel-preview/');
+const API_LAYOUT = URLExt.join(API_ROOT, '/layout/');
 
 /**
  * A micro manager that contains the document context
  */
 export class ContextManager implements IDisposable {
   _wManager: any;
+  private _app: JupyterFrontEnd;
   private _context: DocumentRegistry.IContext<DocumentRegistry.IModel> | null;
   private _comm: Kernel.IComm | undefined;
 
   constructor(
+    app: JupyterFrontEnd,
     context: DocumentRegistry.IContext<DocumentRegistry.IModel>,
     manager: any
   ) {
+    this._app = app;
     this._context = context;
     this._wManager = manager;
 
     this._comm = undefined;
+    context.saveState.connect(
+      async (context: any, status: string) => {
+	if (status != 'started') {
+	  return
+	}
+	const layout_path = URLExt.join(API_LAYOUT, context.path)
+	let response = await fetch(layout_path, {method: 'GET'}, this._app.serviceManager.serverSettings)
+	if (response.status !== 200)
+	  return
+	const layout = await response.json()
+	let changed = false;
+	for (const cell of context.model.cells) {
+	  const cell_layout = layout.cells[cell.id]
+	  const cell_meta = cell.getMetadata()
+	  if (!JSONExt.deepEqual(cell_meta['panel-layout'], cell_layout)) {
+	    cell.setMetadata('panel-layout', cell_layout)
+	    changed = true
+	  }
+	}
+	const nb_meta = context.model.getMetadata()
+	if (!JSONExt.deepEqual(nb_meta['panel-cell-order'], layout.order)) {
+	  context.model.setMetadata('panel-cell-order', layout.order)
+	  changed = true
+	}
+	if (changed) {
+	  context.save()
+	}
+      }
+    )
     context.sessionContext.statusChanged.connect(
-      (session: any, status: any) => {
+      (session: any, status: string) => {
         if (status === 'restarting' || status === 'dead') {
           this._comm = undefined;
         }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -178,6 +178,11 @@ class LumenRenderButton
 
 export class NBWidgetExtension implements INBWidgetExtension {
   _docmanager!: IDocumentManager;
+  _app: JupyterFrontEnd;
+
+  constructor(app: JupyterFrontEnd) {
+    this._app = app
+  }
 
   createNew(
     nb: NotebookPanel,
@@ -196,7 +201,7 @@ export class NBWidgetExtension implements INBWidgetExtension {
       ] as any);
     }
 
-    const manager = new ContextManager(context, renderer.manager);
+    const manager = new ContextManager(this._app, context, renderer.manager);
 
     nb.content.rendermime.addFactory(
       {
@@ -248,7 +253,7 @@ export const extension: JupyterFrontEndPlugin<IPanelPreviewTracker> = {
     menu: IMainMenu | null,
     settingRegistry: ISettingRegistry | null
   ) => {
-    const nb_extension = new NBWidgetExtension();
+    const nb_extension = new NBWidgetExtension(app);
     nb_extension._docmanager = docmanager;
     app.docRegistry.addWidgetExtension('Notebook', nb_extension);
 


### PR DESCRIPTION
This PR adds a save handler which will query an endpoint the `/panel-preview/layout` endpoint to check if there is any layout information that should be persisted inside the notebook and then writes those metadata changes to disk. This approach makes it possible to persist information in the notebook model without causing the notebook to indicate it is stale and require a reload.