### PR TITLE
Ensure Widget Manager can be defined asynchronously

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -18,7 +18,7 @@ const API_LAYOUT = URLExt.join(API_ROOT, '/layout/');
  * A micro manager that contains the document context
  */
 export class ContextManager implements IDisposable {
-  _wManager: any;
+  _widget_renderer: any;
   private _app: JupyterFrontEnd;
   private _context: DocumentRegistry.IContext<DocumentRegistry.IModel> | null;
   private _comm: Kernel.IComm | undefined;
@@ -26,11 +26,11 @@ export class ContextManager implements IDisposable {
   constructor(
     app: JupyterFrontEnd,
     context: DocumentRegistry.IContext<DocumentRegistry.IModel>,
-    manager: any
+    renderer: any
   ) {
     this._app = app;
     this._context = context;
-    this._wManager = manager;
+    this._widget_renderer = renderer;
 
     this._comm = undefined;
     context.saveState.connect(async (context: any, status: string) => {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -201,7 +201,7 @@ export class NBWidgetExtension implements INBWidgetExtension {
       ] as any);
     }
 
-    const manager = new ContextManager(this._app, context, renderer.manager);
+    const manager = new ContextManager(this._app, context, renderer);
 
     nb.content.rendermime.addFactory(
       {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -106,13 +106,25 @@ export class HVJSExec extends Widget implements IRenderMime.IRenderer {
 
   _registerKernel(id: string): void {
     const set_state = (state: any): Promise<any[]> => {
-      return this._manager._wManager.set_state(state);
+      return new Promise((resolve, reject) => {
+	const startTime = Date.now();
+	const checkVariable = async () => {
+	  if (this._manager._widget_renderer.manager !== null) {
+            resolve(await this._manager._widget_renderer.manager.set_state(state));
+	  } else if (Date.now() - startTime >= 5000) {
+            reject(new Error("Initialization of widget manager timed out after 5 seconds."));
+	  } else {
+            setTimeout(checkVariable, 100);
+	  }
+	};
+	checkVariable()
+      })
     };
     const create_view = (model: any, options?: any): any => {
-      return this._manager._wManager.create_view(model, options);
+      return this._manager._widget_renderer.manager.create_view(model, options);
     };
     const display_view = (view: any, el: any): any => {
-      return this._manager._wManager.display_view(view, el);
+      return this._manager._widget_renderer.manager.display_view(view, el);
     };
     const widget_manager: IWidgetManagerProxy = {
       create_view,

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -110,15 +110,21 @@ export class HVJSExec extends Widget implements IRenderMime.IRenderer {
         const startTime = Date.now();
         const checkVariable = async () => {
           if (this._manager._widget_renderer.manager !== null) {
-            resolve(await this._manager._widget_renderer.manager.set_state(state));
+            resolve(
+              await this._manager._widget_renderer.manager.set_state(state)
+            );
           } else if (Date.now() - startTime >= 5000) {
-            reject(new Error("Initialization of widget manager timed out after 5 seconds."));
+            reject(
+              new Error(
+                'Initialization of widget manager timed out after 5 seconds.'
+              )
+            );
           } else {
             setTimeout(checkVariable, 100);
           }
         };
-        checkVariable()
-      })
+        checkVariable();
+      });
     };
     const create_view = (model: any, options?: any): any => {
       return this._manager._widget_renderer.manager.create_view(model, options);

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -107,17 +107,17 @@ export class HVJSExec extends Widget implements IRenderMime.IRenderer {
   _registerKernel(id: string): void {
     const set_state = (state: any): Promise<any[]> => {
       return new Promise((resolve, reject) => {
-	const startTime = Date.now();
-	const checkVariable = async () => {
-	  if (this._manager._widget_renderer.manager !== null) {
+        const startTime = Date.now();
+        const checkVariable = async () => {
+          if (this._manager._widget_renderer.manager !== null) {
             resolve(await this._manager._widget_renderer.manager.set_state(state));
-	  } else if (Date.now() - startTime >= 5000) {
+          } else if (Date.now() - startTime >= 5000) {
             reject(new Error("Initialization of widget manager timed out after 5 seconds."));
-	  } else {
+          } else {
             setTimeout(checkVariable, 100);
-	  }
-	};
-	checkVariable()
+          }
+        };
+        checkVariable()
       })
     };
     const create_view = (model: any, options?: any): any => {


### PR DESCRIPTION
As described in https://github.com/holoviz/pyviz_comms/issues/129, the Jupyter folks changed things such that `registerWidgetManager` now works asynchronously. Since we passed the (now undefined) manager variable to our `ContextManager` this meant it would never be correctly defined and rendering IPyWidgets was broken. This resolves this issue by passing through the renderer object that the manager will be defined on and waiting until it is resolved.