### PR TITLE
enh: Add warning if Panel is not installed with Panel Preview

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -80,14 +80,7 @@ export namespace CommandIDs {
   export const lumenOpen = 'notebook:open-with-lumen';
 }
 
-const TOOLTIP_CONTENT = `
-<span>Preview with Panel<span>
-<br>
-<br>
-<span>
-  <b>Note:</b> Your notebook must publish Panel contents with .servable().
-<span>
-`;
+const TOOLTIP_CONTENT = '<span>Preview with Panel<span>';
 
 /**
  * A notebook widget extension that adds a panel preview button to the toolbar.

--- a/src/preview.tsx
+++ b/src/preview.tsx
@@ -61,7 +61,11 @@ export class CustomIFrame extends IFrame {
     if (value !== null) {
       iframe.setAttribute('srcdoc', value);
       if (this._clearSrcDocOnLoad) {
-        iframe.addEventListener('load', () => iframe.removeAttribute('srcdoc'));
+        iframe.addEventListener('load', () => {
+          if (this._clearSrcDocOnLoad) {
+            iframe.removeAttribute('srcdoc');
+          }
+        });
       }
     }
   }
@@ -76,16 +80,19 @@ export class CustomIFrame extends IFrame {
     iframe.dataset.absoluteUrl = value;
   }
 
+  get clearSrcDocOnLoad() {
+    return this._clearSrcDocOnLoad;
+  }
+
+  set clearSrcDocOnLoad(value: boolean) {
+    this._clearSrcDocOnLoad = value;
+  }
+
   private _srcdoc!: string | null;
   private _clearSrcDocOnLoad: boolean;
 }
 
-const CUSTOM_LOADER = `
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Jupyter Kernel Starting</title>
-  <link href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@900&display=swap" rel="stylesheet">
+const SHARED_STYLES = `
   <style>
     body {
       display: flex;
@@ -94,13 +101,54 @@ const CUSTOM_LOADER = `
       flex-direction: column;
       height: 100vh;
       background-color: #f7f7f7;
-      font-family: "Kumbh Sans", "Segoe UI", Arial, Helvetica, sans-serif;
+      font-family: Arial, Helvetica, sans-serif;
     }
 
     h1 {
       font-weight: 900;
     }
+  </style>
+`;
 
+const PANEL_NOT_INSTALLED_HTML = `
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Panel Not Found</title>
+  ${SHARED_STYLES}
+  <style>
+    p {
+      font-size: 1.1em;
+      color: #444;
+      margin: 6px 0;
+      text-align: center;
+    }
+
+    code {
+      background: #e0e0e0;
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-size: 1em;
+    }
+  </style>
+</head>
+<body>
+  ${panelSvgStr}
+  <h1>Panel is not installed</h1>
+  <p>The Panel preview requires Panel to be installed in the Python environment that launched Jupyter Lab.</p>
+  <p>Install it with: <code>pip install panel</code> or <code>conda install panel</code></p>
+  <p>Then restart Jupyter Lab.</p>
+</body>
+</html>
+`;
+
+const CUSTOM_LOADER = `
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Jupyter Kernel Starting</title>
+  ${SHARED_STYLES}
+  <style>
     .loading-container {
       display: flex;
       align-items: center;
@@ -189,16 +237,21 @@ export class PanelPreview extends DocumentWidget<
 
     const populateIframe = async (path: string) => {
       const panelUrl = getPanelUrl(path);
+      const response = await ServerConnection.makeRequest(
+        panelUrl,
+        {},
+        settings
+      );
+      if (!response.ok) {
+        this.content.clearSrcDocOnLoad = false;
+        this.content.srcdoc = PANEL_NOT_INSTALLED_HTML;
+        return;
+      }
       if (isJupyterHub && panelUrl.startsWith(settings.baseUrl)) {
         // if running on JupyterHub and the panel preview is served
         // from the same domain as JupyterHub, the CSP will forbid
         // embedding the page handled by JupyterHub in the iframe,
         // thus we need to set the content via the `srcdoc` attribute.
-        const response = await ServerConnection.makeRequest(
-          panelUrl,
-          {},
-          settings
-        );
         this.content.srcdoc = await response.text();
         // Bokeh needs to know the absolute URL to determine the appropriate
         // protocol and URL for the websocket; this is set as a data attribute.


### PR DESCRIPTION
## Description

<!--
Using AI? READ FIRST: https://holoviz.org/contribute.html#ai-readme

- Summarize the change and which issue is fixed.
- Include relevant motivation and context.
- Add visuals when possible, e.g. before/after screenshots with full code snippets.
-->

Noticed that if we have launched Jupyter Lab from an environment without Panel installed we get a 404. Not sure if this is overkill, but now we get an error message:

<img width="670" height="1278" alt="image" src="https://github.com/user-attachments/assets/17bfe0d4-bd75-48a7-9698-3d42e6081190" />


## How Has This Been Tested?

<!-- Describe the tests that you ran to verify your changes. Provide instructions so it can be reproduced while reviewing your changes. -->

## AI Disclosure

<!-- Remove this section if your PR does not contain AI-generated content. -->
<!-- Failure in disclosing the use of AI will result in a ban. -->

- [x] This PR contains AI-generated content.
  - [x] I have tested all AI-generated content in my PR.
  - [x] I take responsibility for all AI-generated content in my PR.

<!-- If you used AI to generate code, please specify the tool and model used, and briefly describe how they were used. -->

Tools and Models: Claude Code + Sonnet 4.6, Added to make the HTML and find the best place to put it.
